### PR TITLE
Drop Node 6.x support

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest]
-        node: [ '12', '10', '8', '6' ]
+        node: [ '12', '10', '8' ]
     name: CI - Node ${{ matrix.node }} (${{ matrix.platform }})
     runs-on: ${{ matrix.platform }}
     steps:

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "url": "https://github.com/R4356th/minhtml/issues"
   },
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "scripts": {
     "dist": "grunt dist",


### PR DESCRIPTION
This drops Node 6.x support which reached its end of life in 2019. At least 8.x will be needed from now on. 