### PR TITLE
Drop Node 8.x Support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest]
-        node: [ '12', '10', '8' ]
+        node: [ '12', '10']
     name: CI - Node ${{ matrix.node }} (${{ matrix.platform }})
     runs-on: ${{ matrix.platform }}
     steps:

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "url": "https://github.com/R4356th/minhtml/issues"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=10"
   },
   "scripts": {
     "dist": "grunt dist",


### PR DESCRIPTION
Node.js 8.x has reached its end of life and is blocking some dependency updates. 