### PR TITLE
Migrate Terser Minification Build Step Away from Grunt

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -63,26 +63,10 @@ module.exports = function(grunt) {
         '$1<%= qunit_ver %>$2'
       ]
     },
-
-    terser: {
-      options: {
-        compress: true,
-        mangle: true
-      },
-      beautify: {
-        comments: 'all'
-      },
-      minify: {
-        files: {
-          'dist/htmlminifier.min.js': '<%= browserify.src.dest %>'
-        }
-      }
-    }
   });
 
   grunt.loadNpmTasks('grunt-browserify');
-  grunt.loadNpmTasks('grunt-terser');
-
+  
   function report(type, details) {
     grunt.log.writeln(type + ' completed in ' + details.runtime + 'ms');
     details.failures.forEach(function(details) {
@@ -150,8 +134,7 @@ module.exports = function(grunt) {
 
   grunt.registerTask('dist', [
     'replace',
-    'browserify',
-    'terser'
+    'browserify'
   ]);
 
   grunt.registerTask('test', function() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1681,15 +1681,6 @@
         "which": "~2.0.2"
       }
     },
-    "grunt-terser": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/grunt-terser/-/grunt-terser-1.0.0.tgz",
-      "integrity": "sha512-8MfNU3cVP4UWZLlIjJMUpk3NWIEmaD+CwewhDpUTiPaS49EkBiSWCmGAihqWxBKbiOC3KePPXMmB/yiaVNqW2w==",
-      "dev": true,
-      "requires": {
-        "terser": "^4.3.9"
-      }
-    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "minify": "terser dist/htmlminifier.js --compress --mangle --output dist/htmlminifier.min.js",
     "dist": "npm run minify && grunt dist",
     "lint": "eslint . --ext .js --cache",
-    "test": "npm run lint && grunt test"
+    "test": "npm run minify && npm run lint && grunt test"
   },
   "keywords": [
     "cli",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "eslint": "^7.27.0",
     "grunt": "1.4.1",
     "grunt-browserify": "^6.0.0",
-    "grunt-terser": "^1.0.0",
     "node-qunit-puppeteer": "2.0.3",
     "qunit": "^2.15.0"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "description": "Highly configurable, well-tested JavaScript-based HTML minifier.",
   "version": "0.2.0",
   "scripts": {
-    "dist": "grunt dist",
+    "minify": "terser dist/htmlminifier.js --compress --mangle --output dist/htmlminifier.min.js",
+    "dist": "npm run minify && grunt dist",
     "lint": "eslint . --ext .js --cache",
     "test": "npm run lint && grunt test"
   },


### PR DESCRIPTION
This migrates the Terser minification build step away from Grunt as a part of #16.