### PR TITLE
Revert "Bump commander from 4.1.1 to 7.2.0"

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -37,7 +37,7 @@ module.exports = function(grunt) {
             './src/htmlminifier.js:minhtml'
           ]
         },
-        src: 'src/htmlminifier.js',
+        src: 'src/htmlminifier.js'
       }
     },
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -731,9 +731,9 @@
       }
     },
     "commander": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="
     },
     "concat-map": {
       "version": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "camel-case": "^4.1.2",
     "clean-css": "^4.2.3",
-    "commander": "^7.2.0",
+    "commander": "^4.1.1",
     "he": "^1.2.0",
     "param-case": "^3.0.4",
     "relateurl": "^0.2.7",


### PR DESCRIPTION
Reverts R4356th/minhtml#10 which seems to have broke the CLI.